### PR TITLE
Add W-OVERFLOW Loom to the list of Loom IDs

### DIFF
--- a/src/main/java/juuxel/loomquiltflower/api/LoomQuiltflowerPlugin.java
+++ b/src/main/java/juuxel/loomquiltflower/api/LoomQuiltflowerPlugin.java
@@ -18,6 +18,7 @@ public class LoomQuiltflowerPlugin implements Plugin<Project> {
         "dev.architectury.loom",
         "org.quiltmc.loom",
         "gg.essential.loom", // https://github.com/Sk1erLLC/architectury-loom
+        "cc.woverlfow.loom" // https://github.com/W-OVERFLOW/Loom
     });
     private boolean applied = false;
 


### PR DESCRIPTION
Adding this so we don't get an error xD, would rather have it in the official LoomQuiltflower but if you don't want to add it thats understandable we can just mirror it with our loom.