### PR TITLE
Allow Babric Loom to be used with QuiltFlower

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ use [loom-quiltflower-mini](https://github.com/Juuxel/loom-quiltflower-mini) ins
 | Architectury Loom    | `dev.architectury.loom` | 0.7.2, 0.7.4, 0.10.0¹, 0.11.0 |
 | Quilt Loom           | `org.quiltmc.loom`      | 0.12                          |
 | `gg.essential.loom`  | `gg.essential.loom`     | *None*²                       |
+| Babric Loom          | `babric-loom`           | 0.12                          |
 
 ¹ From build 0.10.0.206 onwards  
 ² Completely untested

--- a/src/main/java/juuxel/loomquiltflower/api/LoomQuiltflowerPlugin.java
+++ b/src/main/java/juuxel/loomquiltflower/api/LoomQuiltflowerPlugin.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 public class LoomQuiltflowerPlugin implements Plugin<Project> {
     private static final List<String> LOOMS = List.of(new String[] {
+        "babric-loom", // https://github.com/babric/fabric-loom
         "fabric-loom",
         "dev.architectury.loom",
         "org.quiltmc.loom",


### PR DESCRIPTION
Adds [`babric-loom`](https://github.com/babric/fabric-loom) to the list of supported Loom plugins, so QuiltFlower can be used as a decompiler with [Babric](https://github.com/babric/).