### PR TITLE
Add support for Ornithe Loom

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ use [loom-quiltflower-mini](https://github.com/Juuxel/loom-quiltflower-mini) ins
 | Quilt Loom           | `org.quiltmc.loom`      | 0.12, 1.0                             |
 | `gg.essential.loom`  | `gg.essential.loom`     | *None*²                               |
 | Babric Loom          | `babric-loom`           | 0.12²                                 |
+| Ornithe Loom         | `ornithe-loom`          | 1.0²                                  |
 
 ¹ From build 0.10.0.206 onwards  
 ² Completely untested

--- a/src/main/java/juuxel/loomquiltflower/api/LoomQuiltflowerPlugin.java
+++ b/src/main/java/juuxel/loomquiltflower/api/LoomQuiltflowerPlugin.java
@@ -19,6 +19,7 @@ public class LoomQuiltflowerPlugin implements Plugin<Project> {
         "org.quiltmc.loom",
         "gg.essential.loom", // https://github.com/Sk1erLLC/architectury-loom
         "babric-loom", // https://github.com/babric/fabric-loom
+        "ornithe-loom", // https://github.com/OrnitheMC/ornithe-loom
     });
     private boolean applied = false;
 


### PR DESCRIPTION
allow LoomQuiltflower to be used in [Ornithe Loom](https://github.com/OrnitheMC/ornithe-loom).